### PR TITLE
chore: version script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ websites.
     <script
       type="module"
       src="https://cdn.jsdelivr.net/npm/@europeana/feedback-widget@0.1.0-rc.4/dist/europeana-feedback-widget.js"
-      integrity="sha384-w3k1iYmZcTD//J+fYTbS3BVA2MFsbNV0HkEj2gIVkVEoV67BH4aoroUoVYzF96BT"
+      integrity="sha384-m56odkxmqwWoDSQCF33mMYpmxjGSqbPNsuBy/JgQH6s81P2I1CZHqbu5exG5JhHL"
     ></script>
   </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ websites.
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@europeana/feedback-widget/dist/europeana-feedback-widget.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@europeana/feedback-widget@0.1.0-rc.4/dist/europeana-feedback-widget.css" />
   </head>
   <body>
     <div id="europeana-feedback-widget"></div>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@europeana/feedback-widget/dist/europeana-feedback-widget.js"></script>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@europeana/feedback-widget@0.1.0-rc.4/dist/europeana-feedback-widget.js"
+      integrity="sha384-w3k1iYmZcTD//J+fYTbS3BVA2MFsbNV0HkEj2gIVkVEoV67BH4aoroUoVYzF96BT"
+    ></script>
   </body>
 </html>
 ```
@@ -28,6 +32,7 @@ websites.
 * Check code formatting: `pnpm format`
 * Check code quality: `pnpm lint`
 * Build library: `pnpm build`
+* Version library: `pnpm version patch`
 * Publish library to NPM: `pnpm publish --access public`
 
 

--- a/bin/version.js
+++ b/bin/version.js
@@ -1,23 +1,17 @@
 import fs from 'fs'
 import ssri from 'ssri'
 
-import pkg from '../package.json' assert { type: 'json' }
-
-console.log('pkg version', pkg.version)
-
 const readmeUrl = new URL('../README.md', import.meta.url)
 
 let readme = fs.readFileSync(readmeUrl, { encoding: 'utf8' })
 
+import pkg from '../package.json' assert { type: 'json' }
 readme = readme.replace(/@europeana\/feedback-widget(@.+)?\/dist\//g, `@europeana/feedback-widget@${pkg.version}/dist/`)
 
 const distScriptUrl = new URL('../dist/europeana-feedback-widget.js', import.meta.url)
 const distScriptIntegrity = ssri.fromData(fs.readFileSync(distScriptUrl), {
   algorithms: ['sha384']
 })
-console.log('distScriptIntegrity', distScriptIntegrity)
 readme = readme.replace(/integrity="sha384-[^"]*"/g, `integrity="${distScriptIntegrity.sha384.toString()}"`)
 
 fs.writeFileSync(readmeUrl, readme)
-
-process.exit(1)

--- a/bin/version.js
+++ b/bin/version.js
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import ssri from 'ssri'
+
+import pkg from '../package.json' assert { type: 'json' }
+
+console.log('pkg version', pkg.version)
+
+const readmeUrl = new URL('../README.md', import.meta.url)
+
+let readme = fs.readFileSync(readmeUrl, { encoding: 'utf8' })
+
+readme = readme.replace(/@europeana\/feedback-widget(@.+)?\/dist\//g, `@europeana/feedback-widget@${pkg.version}/dist/`)
+
+const distScriptUrl = new URL('../dist/europeana-feedback-widget.js', import.meta.url)
+const distScriptIntegrity = ssri.fromData(fs.readFileSync(distScriptUrl), {
+  algorithms: ['sha384']
+})
+console.log('distScriptIntegrity', distScriptIntegrity)
+readme = readme.replace(/integrity="sha384-[^"]*"/g, `integrity="${distScriptIntegrity.sha384.toString()}"`)
+
+fs.writeFileSync(readmeUrl, readme)
+
+process.exit(1)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "preview": "vite preview",
     "test:unit": "vitest",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --ignore-path .gitignore",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "preversion": "build",
+    "version": "node ./bin/version.js && git add README.md"
   },
   "dependencies": {
     "@europeana/style": "1.138.1",
@@ -45,6 +47,7 @@
     "nodemon": "^3.0.3",
     "prettier": "^3.0.3",
     "sass": "^1.69.7",
+    "ssri": "^10.0.5",
     "vite": "^5.0.10",
     "vite-svg-loader": "^5.1.0",
     "vitest": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:unit": "vitest",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --ignore-path .gitignore",
     "format": "prettier --write src/",
-    "preversion": "build",
+    "preversion": "npm run build",
     "version": "node ./bin/version.js && git add README.md"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ devDependencies:
   sass:
     specifier: ^1.69.7
     version: 1.69.7
+  ssri:
+    specifier: ^10.0.5
+    version: 10.0.5
   vite:
     specifier: ^5.0.10
     version: 5.0.11(sass@1.69.7)
@@ -2728,6 +2731,13 @@ packages:
 
   /spawn-command@0.0.2:
     resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
+    dev: true
+
+  /ssri@10.0.5:
+    resolution: {integrity: sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      minipass: 7.0.4
     dev: true
 
   /stackback@0.0.2:


### PR DESCRIPTION
Run `pnpm version patch` and README.md will be updated with links to the latest version files on CDN, including the script integrity hash.